### PR TITLE
resurrect: Update properly when the unit is successfully resurrected

### DIFF
--- a/elements/resurrect.lua
+++ b/elements/resurrect.lua
@@ -32,7 +32,10 @@
 local parent, ns = ...
 local oUF = ns.oUF
 
-local Update = function(self, event)
+local Path
+local Update = function(self, event, unit)
+	if(self.unit ~= unit) then return end
+
 	local resurrect = self.ResurrectIcon
 	if(resurrect.PreUpdate) then
 		resurrect:PreUpdate()
@@ -41,8 +44,10 @@ local Update = function(self, event)
 	local incomingResurrect = UnitHasIncomingResurrection(self.unit)
 	if(incomingResurrect) then
 		resurrect:Show()
+		self:RegisterEvent('UNIT_HEALTH', Path)
 	else
 		resurrect:Hide()
+		self:UnregisterEvent('UNIT_HEALTH', Path)
 	end
 
 	if(resurrect.PostUpdate) then
@@ -50,7 +55,7 @@ local Update = function(self, event)
 	end
 end
 
-local Path = function(self, ...)
+Path = function(self, ...)
 	return (self.ResurrectIcon.Override or Update) (self, ...)
 end
 


### PR DESCRIPTION
INCOMING_RESURRECT_CHANGED is not dependable, and I've often seen that once the unit is successfully resurrected, the icon gets stuck.