### PR TITLE
castbar: Kill the pet casting bar if we spawn a player castbar

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -457,7 +457,7 @@ local Enable = function(object, unit)
 			CastingBarFrame:UnregisterAllEvents()
 			CastingBarFrame.Show = CastingBarFrame.Hide
 			CastingBarFrame:Hide()
-		elseif(object.unit == 'pet') then
+
 			PetCastingBarFrame:UnregisterAllEvents()
 			PetCastingBarFrame.Show = PetCastingBarFrame.Hide
 			PetCastingBarFrame:Hide()


### PR DESCRIPTION
PetCastingBarFrame is only ever used for possessed units, we need to disable it on the player unit instead of the pet.

This resolves #220.