### PR TITLE
runebar: Bail if GetRuneCooldown returns nil values

### DIFF
--- a/elements/runebar.lua
+++ b/elements/runebar.lua
@@ -92,6 +92,11 @@ local UpdateRune = function(self, event, rid)
 	end
 
 	local start, duration, runeReady = GetRuneCooldown(rid)
+	if(not start) then
+		-- As of 6.2.0 GetRuneCooldown returns nil values when zoning
+		return
+	end
+
 	if(runeReady) then
 		rune:SetMinMaxValues(0, 1)
 		rune:SetValue(1)


### PR DESCRIPTION
Since 6.2, `GetRuneCooldown` returns nil values during loading screens, which result in errors being spewed.

It is most likely an issue with the API, but it's probably best to check for it to avoid errors.

Discussion: http://www.wowinterface.com/forums/showthread.php?t=52535