### PR TITLE
altpowerbar: Some tweaks

### DIFF
--- a/elements/altpowerbar.lua
+++ b/elements/altpowerbar.lua
@@ -89,7 +89,7 @@ local UpdatePower = function(self, event, unit, powerType)
 	local cur = UnitPower(unit, ALTERNATE_POWER_INDEX)
 	local max = UnitPowerMax(unit, ALTERNATE_POWER_INDEX)
 
-	local barType, min, _, _, _, _, _, _, _, powerName, powerTooltip = UnitAlternatePowerInfo(unit)
+	local barType, min, _, _, _, _, _, _, _, _, powerName, powerTooltip = UnitAlternatePowerInfo(unit)
 	altpowerbar.barType = barType
 	altpowerbar.powerName = powerName
 	altpowerbar.powerTooltip = powerTooltip

--- a/elements/altpowerbar.lua
+++ b/elements/altpowerbar.lua
@@ -165,7 +165,10 @@ local Enable = function(self, unit)
 			if(not altpowerbar:GetScript('OnEnter')) then
 				altpowerbar:SetScript('OnEnter', OnEnter)
 			end
-			altpowerbar:SetScript('OnLeave', OnLeave)
+
+			if(not altpowerbar:GetScript('OnLeave')) then
+				altpowerbar:SetScript('OnLeave', OnLeave)
+			end
 
 			if(not altpowerbar.UpdateTooltip) then
 				altpowerbar.UpdateTooltip = UpdateTooltip


### PR DESCRIPTION
Since 6.2, I guess, Blizzard changed ```UnitAlternatePowerInfo()``` by adding one more return value.

It is also illogical to override possibly existing ```OnLeave``` script.