### PR TITLE
Legion classicons

### DIFF
--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -214,7 +214,12 @@ do
 	elseif(PlayerClass == 'PALADIN') then
 		ClassPowerID = SPELL_POWER_HOLY_POWER
 		ClassPowerType = "HOLY_POWER"
-		RequireSpell = 85673 -- Word of Glory
+
+		if(isBetaClient) then
+			RequireSpec = SPEC_PALADIN_RETRIBUTION
+		else
+			RequireSpell = 85673 -- Word of Glory
+		end
 	elseif(PlayerClass == 'PRIEST') then
 		ClassPowerID = SPELL_POWER_SHADOW_ORBS
 		ClassPowerType = "SHADOW_ORBS"

--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -12,7 +12,6 @@
 
  Monk    - Chi Orbs
  Paladin - Holy Power
- Priest  - Shadow Orbs
  Warlock - Soul Shards
 
  Examples
@@ -220,7 +219,7 @@ do
 		else
 			RequireSpell = 85673 -- Word of Glory
 		end
-	elseif(PlayerClass == 'PRIEST') then
+	elseif(PlayerClass == 'PRIEST' and not isBetaClient) then
 		ClassPowerID = SPELL_POWER_SHADOW_ORBS
 		ClassPowerType = "SHADOW_ORBS"
 		RequireSpec = SPEC_PRIEST_SHADOW

--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -50,6 +50,8 @@
 local parent, ns = ...
 local oUF = ns.oUF
 
+local isBetaClient = select(4, GetBuildInfo()) >= 70000
+
 local _, PlayerClass = UnitClass'player'
 
 -- Holds the class specific stuff.
@@ -205,6 +207,10 @@ do
 	if(PlayerClass == 'MONK') then
 		ClassPowerID = SPELL_POWER_CHI
 		ClassPowerType = "CHI"
+
+		if(isBetaClient) then
+			RequireSpec = SPEC_MONK_WINDWALKER
+		end
 	elseif(PlayerClass == 'PALADIN') then
 		ClassPowerID = SPELL_POWER_HOLY_POWER
 		ClassPowerType = "HOLY_POWER"

--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -227,8 +227,11 @@ do
 	elseif(PlayerClass == 'WARLOCK') then
 		ClassPowerID = SPELL_POWER_SOUL_SHARDS
 		ClassPowerType = "SOUL_SHARDS"
-		RequireSpec = SPEC_WARLOCK_AFFLICTION
-		RequireSpell = WARLOCK_SOULBURN
+
+		if(not isBetaClient) then
+			RequireSpec = SPEC_WARLOCK_AFFLICTION
+			RequireSpell = WARLOCK_SOULBURN
+		end
 	end
 end
 

--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -62,27 +62,14 @@ local ClassPowerEnable, ClassPowerDisable
 local RequireSpec, RequireSpell
 
 local UpdateTexture = function(element)
-	local red, green, blue, desaturated
-	if(PlayerClass == 'MONK') then
-		red, green, blue = 0, 1, .59
-		desaturated = true
-	elseif(PlayerClass == 'WARLOCK') then
-		red, green, blue = 1, .5, 1
-		desaturated = true
-	elseif(PlayerClass == 'PRIEST') then
-		red, green, blue = 1, 1, 1
-	elseif(PlayerClass == 'PALADIN') then
-		red, green, blue = 1, .96, .41
-		desaturated = true
-	end
-
+	local color = oUF.colors.power[ClassPowerType]
 	for i = 1, #element do
 		local icon = element[i]
 		if(icon.SetDesaturated) then
-			icon:SetDesaturated(desaturated)
+			icon:SetDesaturated(PlayerClass ~= 'PRIEST')
 		end
 
-		icon:SetVertexColor(red, green, blue)
+		icon:SetVertexColor(color[1], color[2], color[3])
 	end
 end
 

--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -134,10 +134,11 @@ local Update = function(self, event, unit, powerType)
 	 max           - The maximum amount of power
 	 hasMaxChanged - Shows if the maximum amount has changed since the last
 	                 update
+	 powerType     - The type of power used
 	 event         - The event, which the update happened for
 	]]
 	if(element.PostUpdate) then
-		return element:PostUpdate(cur, max, oldMax ~= max, event)
+		return element:PostUpdate(cur, max, oldMax ~= max, powerType, event)
 	end
 end
 

--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -10,6 +10,7 @@
 
  Notes
 
+ Mage    - Arcane Charges
  Monk    - Chi Orbs
  Paladin - Holy Power
  Warlock - Soul Shards
@@ -232,6 +233,10 @@ do
 			RequireSpec = SPEC_WARLOCK_AFFLICTION
 			RequireSpell = WARLOCK_SOULBURN
 		end
+	elseif(PlayerClass == 'MAGE' and isBetaClient) then
+		ClassPowerID = SPELL_POWER_ARCANE_CHARGES
+		ClassPowerType = 'ARCANE_CHARGES'
+		RequireSpec = SPEC_MAGE_ARCANE
 	end
 end
 

--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -10,9 +10,11 @@
 
  Notes
 
+ Druid   - Combo Points
  Mage    - Arcane Charges
  Monk    - Chi Orbs
  Paladin - Holy Power
+ Rogue   - Combo Points
  Warlock - Soul Shards
 
  Examples
@@ -232,6 +234,13 @@ do
 		if(not isBetaClient) then
 			RequireSpec = SPEC_WARLOCK_AFFLICTION
 			RequireSpell = WARLOCK_SOULBURN
+		end
+	elseif(PlayerClass == 'ROGUE' or PlayerClass == 'DRUID') then
+		ClassPowerID = SPELL_POWER_COMBO_POINTS
+		ClassPowerType = 'COMBO_POINTS'
+
+		if(isBetaClient and PlayerClass == 'DRUID') then
+			RequireSpell = 5221 -- Shred
 		end
 	elseif(PlayerClass == 'MAGE' and isBetaClient) then
 		ClassPowerID = SPELL_POWER_ARCANE_CHARGES

--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -253,15 +253,22 @@ local Enable = function(self, unit)
 	element.ClassPowerEnable = ClassPowerEnable
 	element.ClassPowerDisable = ClassPowerDisable
 
+	local isChildrenTextures
 	for i = 1, #element do
 		local icon = element[i]
-		if(icon:IsObjectType'Texture' and not icon:GetTexture()) then
-			icon:SetTexCoord(0.45703125, 0.60546875, 0.44531250, 0.73437500)
-			icon:SetTexture([[Interface\PlayerFrame\Priest-ShadowUI]])
+		if(icon:IsObjectType'Texture') then
+			if(not icon:GetTexture()) then
+				icon:SetTexCoord(0.45703125, 0.60546875, 0.44531250, 0.73437500)
+				icon:SetTexture([[Interface\PlayerFrame\Priest-ShadowUI]])
+			end
+
+			isChildrenTextures = true
 		end
 	end
 
-	(element.UpdateTexture or UpdateTexture) (element)
+	if(isChildrenTextures) then
+		(element.UpdateTexture or UpdateTexture) (element)
+	end
 
 	return true
 end


### PR DESCRIPTION
This PR contains additions/deprecations for the classicons element for Legion.
It depends on #267 to work correctly for Legion.
It also eliminates the need for #223 and #240.

These commits are compatible with both live and beta clients.