### PR TITLE
power: Alternative power colours use both 0-1 and 0-255 ranges.

### DIFF
--- a/elements/power.lua
+++ b/elements/power.lua
@@ -192,10 +192,10 @@ local Update = function(self, event, unit)
 			if(power.GetAlternativeColor) then
 				r, g, b = power:GetAlternativeColor(unit, ptype, ptoken, altR, altG, altB)
 			elseif(altR) then
-				if(altR >= 0 and altR <= 1) and (altG >= 0 and altG <= 1) and (altB >= 0 and altB <= 1) then
-					r, g, b = altR, altG, altB
-				else
+				if(altR > 1) or (altG > 1) or (altB > 1) then
 					r, g, b = altR / 255, altG / 255, altB / 255
+				else
+					r, g, b = altR, altG, altB
 				end
 			else
 				t = self.colors.power[ptype]

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -192,7 +192,11 @@ local Update = function(self, event, unit)
 			if(power.GetAlternativeColor) then
 				r, g, b = power:GetAlternativeColor(unit, ptype, ptoken, altR, altG, altB)
 			elseif(altR) then
-				r, g, b = altR / 255, altG / 255, altB / 255
+				if(altR > 0 and altR < 1) or (altG > 0 and altG < 1) or (altB > 0 and altB < 1) then
+					r, g, b = altR, altG, altB
+				else
+					r, g, b = altR / 255, altG / 255, altB / 255
+				end
 			else
 				t = self.colors.power[ptype]
 			end

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -192,7 +192,7 @@ local Update = function(self, event, unit)
 			if(power.GetAlternativeColor) then
 				r, g, b = power:GetAlternativeColor(unit, ptype, ptoken, altR, altG, altB)
 			elseif(altR) then
-				r, g, b = altR, altG, altB
+				r, g, b = altR / 255, altG / 255, altB / 255
 			else
 				t = self.colors.power[ptype]
 			end

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -192,6 +192,7 @@ local Update = function(self, event, unit)
 			if(power.GetAlternativeColor) then
 				r, g, b = power:GetAlternativeColor(unit, ptype, ptoken, altR, altG, altB)
 			elseif(altR) then
+				-- As of 7.0.3, altR, altG, altB may be in 0-1 or 0-255 range.
 				if(altR > 1) or (altG > 1) or (altB > 1) then
 					r, g, b = altR / 255, altG / 255, altB / 255
 				else

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -192,7 +192,7 @@ local Update = function(self, event, unit)
 			if(power.GetAlternativeColor) then
 				r, g, b = power:GetAlternativeColor(unit, ptype, ptoken, altR, altG, altB)
 			elseif(altR) then
-				if(altR > 0 and altR < 1) or (altG > 0 and altG < 1) or (altB > 0 and altB < 1) then
+				if(altR >= 0 and altR <= 1) and (altG >= 0 and altG <= 1) and (altB >= 0 and altB <= 1) then
 					r, g, b = altR, altG, altB
 				else
 					r, g, b = altR / 255, altG / 255, altB / 255


### PR DESCRIPTION
Hi!

Title says it all. Here's an example.

![image](https://cloud.githubusercontent.com/assets/2725970/17123287/b0e05fcc-530c-11e6-9da0-b26734f092b4.png)
